### PR TITLE
Upgrade to alpine 3.15.0 & AWS CLI 1.22.81

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.12.1
+FROM alpine:3.15.0
 
-ARG AWS_CLI_VERSION=1.18.162
+ARG AWS_CLI_VERSION=1.22.81
 
 ENV BASH_ENV=/etc/profile
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,12 +1,12 @@
 # Release Container
-FROM alpine:3.12.1 as release
+FROM alpine:3.15.0 as release
 
 ENV MIX_ENV=prod
 ENV REPLACE_OS_VARS true
 ENV LC_ALL=en_US.UTF-8
 ENV AWS_ENV_SHA=1393537837dc67d237a9a31c8b4d3dd994022d65e99c1c1e1968edc347aae63f
 
-ARG AWS_CLI_VERSION=1.18.162
+ARG AWS_CLI_VERSION=1.22.81
 RUN apk --no-cache add \
   bash \
   libcrypto1.1 \


### PR DESCRIPTION
In order to upgrade to the latest elixir/erlang releases we need to bump alpine. These hexpm/elixir packages are available: 
 
* [1.13.3-erlang-24.3-alpine-3.14.3](https://hub.docker.com/layers/elixir/hexpm/elixir/1.13.3-erlang-24.3-alpine-3.14.3/images/sha256-3da85a66393237321256c56623d12cad3942cdc964c8090e388432eb7577180f?context=explore)  
* [1.13.3-erlang-24.3-alpine-3.15.0](https://hub.docker.com/layers/elixir/hexpm/elixir/1.13.3-erlang-24.3-alpine-3.15.0/images/sha256-0b8e736d71eb683fb11997adf18100d7112005cf7da26e004e8111a7bbb80d9d?context=explore)