### PR TITLE
bump: alpine 3.15.6

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.3
+FROM alpine:3.15.6
 
 ARG AWS_CLI_VERSION=1.22.81
 

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,5 +1,5 @@
 # Release Container
-FROM alpine:3.15.3 as release
+FROM alpine:3.15.6 as release
 
 ENV MIX_ENV=prod
 ENV REPLACE_OS_VARS true


### PR DESCRIPTION
The version of hexpm/elixir that I'm using uses version 3.15.6